### PR TITLE
Fix a memory leak with os.File

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -30,6 +30,7 @@ func (r *ParserImpl) ReadCsvFromFileInOrder(fileName string, ents interface{}) e
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	return r.ReadCsvInOrder(f, ents)
 }
@@ -39,6 +40,7 @@ func (r *ParserImpl) ReadCsvFromFileWithHeaders(fileName string, ents interface{
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	return r.ReadCsvWithHeaders(f, ents)
 }


### PR DESCRIPTION
Hey, Neve.

os.File needs to close after unusable for I/O.

